### PR TITLE
Feat/suggest products

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -11,20 +11,26 @@ Eres un asistente de pedidos para vendedores de distribuidoras. Sé amable, cola
 
 Entrada típica: "Cliente: items". Ej.: "Supermercado Don Pepe: 10 kg queso la serenisima".
 
-Flujo:
-1) Valida el CLIENTE: llamá a listarClientes (podés filtrar por el nombre). Si no existe, informá claramente: "No encontré el cliente <nombre>." y sugerí los más parecidos.
-2) Identificá productos y cantidades y consultá stock de TODOS con consultarStock.
-3) Si hay datos suficientes, creá ORDEN BORRADOR con crearOrden (o equivalente en herramientas).
-4) ANTES de cerrar el resumen del borrador, RECOMENDÁ POSITIVAMENTE entre 1–3 productos adicionales con sugerirProductos para ayudar a vender más (beneficia la comisión del vendedor y las ventas de la distribuidora). Indicá motivo breve ("expira pronto"/"habitual"), cantidad sugerida y precio.
-5) Respondé con un resumen amigable, por ejemplo:
-"🧾 Pedido a <cliente>\n- <cantidad> × <producto> (<sku>) — stock: <disp>\n➕ Sugerencias: <n> ítems (ej.: <sku> <nombre> × <qty> — $<precio>)\n💰 Total estimado: $<total>\n🆔 Orden borrador: <orderId>\n¿Querés confirmarlo? (sí/no)"
-6) Si el usuario confirma ("sí", "ok", "confirmar"), llamá a confirmarOrden y reportá: "✅ Pedido confirmado: <orderId>". Incluí el detalle por ítem en líneas: "- <cantidad> × <producto> = $<lineTotal>" y el total final.
+Flujo OBLIGATORIO:
+1) Valida el CLIENTE: llamá a listarClientes o buscarClientes (podés filtrar por el nombre). Si no existe, informá claramente: "No encontré el cliente <nombre>." y sugerí los más parecidos.
+2) APENAS IDENTIFIQUES UN CLIENTE VÁLIDO, INMEDIATAMENTE llamá a sugerirProductos para ese cliente. Esto es OBLIGATORIO y debe ser lo PRIMERO que hagas después de identificar el cliente.
+3) SIEMPRE presenta las sugerencias de productos al usuario de manera positiva, mencionando motivos como "productos habituales", "expiran pronto", "populares", etc.
+4) Luego, si el usuario mencionó productos específicos, identificá productos y cantidades y consultá stock con consultarStock.
+5) Si hay datos suficientes, creá ORDEN BORRADOR con crearOrden.
+6) ANTES de cerrar el resumen del borrador, VOLVÉ A RECOMENDAR entre 1–3 productos adicionales basándote en las sugerencias obtenidas.
+7) Respondé con un resumen amigable, por ejemplo:
+"🧾 Pedido para <cliente>\n- <cantidad> × <producto> (<sku>) — stock: <disp>\n➕ Te recomiendo también: <n> productos (ej.: <sku> <nombre> × <qty> — $<precio> - <motivo>)\n💰 Total estimado: $<total>\n🆔 Orden borrador: <orderId>\n¿Querés confirmarlo? (sí/no)"
+8) Si el usuario confirma ("sí", "ok", "confirmar"), llamá a confirmarOrden y reportá: "✅ Pedido confirmado: <orderId>".
 
-Guías:
-- La recomendación NO es opcional: siempre ofrecé 1–3 productos positivos si hay stock.
-- Si faltan datos (cliente o cantidades), pedí lo mínimo con tono colaborativo y agregá ejemplos cortos.
-- No inventes SKUs; si no encontrás el producto, ofrecé alternativas del stock.
+Guías OBLIGATORIAS:
+- SIEMPRE que identifiques un cliente, inmediatamente llamá a sugerirProductos - NO es opcional.
+- Las recomendaciones deben ser POSITIVAS y ÚTILES, no opcionales.
+- Si un vendedor consulta información sobre un comercio, automáticamente buscá sugerencias para ese comercio.
+- Si faltan datos, pedí lo mínimo pero SIEMPRE mostrá sugerencias cuando haya un cliente identificado.
+- No inventes SKUs; usá solo los datos reales del stock.
 - Mantené respuestas breves, claras y con 1–3 emojis máximo.
+
+IMPORTANTE: La función sugerirProductos debe llamarse INMEDIATAMENTE después de identificar cualquier cliente, sin excusas ni demoras.
 `;
 
 export async function POST(req: Request) {
@@ -41,6 +47,15 @@ export async function POST(req: Request) {
       tools,
       system: SYSTEM_PROMPT,
       stopWhen: stepCountIs(8),
+      onStepFinish: ({ text, toolResults, toolCalls, finishReason, usage }) => {
+        console.log("Step finished:", {
+          text: JSON.stringify(text),
+          toolResults: JSON.stringify(toolResults),
+          toolCalls: JSON.stringify(toolCalls),
+          finishReason: JSON.stringify(finishReason),
+          usage: JSON.stringify(usage),
+        });
+      },
     });
 
     return result.toUIMessageStreamResponse();

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -121,14 +121,18 @@ export const sugerirProductos = tool({
       .describe(
         "Fecha de referencia para las sugerencias (formato ISO string, ej: 2024-01-01T00:00:00Z)",
       ),
+    top: z
+      .optional(z.number().int().min(1).max(100).default(10))
+      .describe("Número máximo de productos a sugerir (por defecto 10)"),
   }),
-  execute: async ({ clientId, asOf }) => {
+  execute: async ({ clientId, asOf, top }) => {
     const distributorId = await getDistributorFromContext();
     const referenceDate = asOf ? new Date(asOf) : new Date();
     const suggestions = await suggestionService.suggestProducts(
       distributorId,
       clientId,
       referenceDate,
+      top ?? 10,
     );
     return suggestions;
   },

--- a/src/queries/suggestions.sql
+++ b/src/queries/suggestions.sql
@@ -9,8 +9,9 @@ params AS (
     90                     AS new_days,
     14                     AS avoid_repeat_days,
     30                     AS min_expiry_days,
-    30                     AS top_global_limit,
-    30                     AS top_new_limit
+  30                     AS top_global_limit,
+  30                     AS top_new_limit,
+  :top::int              AS top
 ),
 -- 1) Ventanas de tiempo
 bounds AS (
@@ -143,4 +144,4 @@ ORDER BY
   (CASE WHEN n.product_id IS NOT NULL THEN 1 ELSE 0 END) DESC,
   COALESCE(gs.global_orders_cnt_1y,0)::int DESC,
   COALESCE(ci.client_qty_26w,0)::int DESC
-;
+LIMIT (SELECT top FROM params);

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -51,6 +51,7 @@ export class PrismaUserRepository implements UserRepository {
     clientId: string,
     distributorId: string,
     asOf: Date,
+    top: number,
   ): Promise<SuggestedProduct[]> {
     // Leer el archivo SQL
     const sqlPath = path.join(
@@ -65,7 +66,8 @@ export class PrismaUserRepository implements UserRepository {
     const processedQuery = sqlQuery
       .replace(/:client_id::text/g, `'${clientId}'::text`)
       .replace(/:distributor_id::text/g, `'${distributorId}'::text`)
-      .replace(/:as_of::timestamptz/g, `'${asOf.toISOString()}'::timestamptz`);
+      .replace(/:as_of::timestamptz/g, `'${asOf.toISOString()}'::timestamptz`)
+      .replace(/:top::int/g, `${top}`);
 
     const results =
       await this.prisma.$queryRawUnsafe<SuggestedProduct[]>(processedQuery);

--- a/src/services/suggestion.service.ts
+++ b/src/services/suggestion.service.ts
@@ -6,7 +6,13 @@ export const suggestionService = {
     distributorId: string,
     clientId: string,
     asOf: Date = new Date(),
+    top: number,
   ): Promise<SuggestedProduct[]> {
-    return await userRepo.getSuggestedProducts(clientId, distributorId, asOf);
+    return await userRepo.getSuggestedProducts(
+      clientId,
+      distributorId,
+      asOf,
+      top,
+    );
   },
 };


### PR DESCRIPTION
This pull request introduces important changes to the product suggestion workflow for vendor order assistants, making product recommendations more proactive and configurable. The main improvements are enforcing immediate product suggestions after client identification, allowing configuration of the number of suggested products, and updating the SQL query and backend logic to support this. Debugging has also been enhanced with step-level logging.

**Product Suggestion Workflow Updates:**

* The assistant now calls `sugerirProductos` immediately after identifying a client, ensuring product recommendations are always presented at the start of the order flow. Recommendations are required and must be positive and useful, with clear guidance in the system prompt (`src/app/api/chat/route.ts`).
* The `sugerirProductos` tool now accepts a configurable `top` parameter to control the maximum number of products suggested (default is 10), making recommendations more flexible (`src/lib/ai/tools.ts`).

**Backend and SQL Integration:**

* The suggestions SQL query and repository logic have been updated to accept and use the `top` parameter, limiting the number of products returned (`src/queries/suggestions.sql`, `src/repositories/user.repository.ts`, `src/services/suggestion.service.ts`). [[1]](diffhunk://#diff-81b77b19d712299df87274fd9e4138020e0f9f9253dd432cd5820bcde0795aceL13-R14) [[2]](diffhunk://#diff-81b77b19d712299df87274fd9e4138020e0f9f9253dd432cd5820bcde0795aceL146-R147) [[3]](diffhunk://#diff-e382eb5a130dc151e020e68e0e50ba1f26f21a341f605178fbd468154ea8f66cR54) [[4]](diffhunk://#diff-e382eb5a130dc151e020e68e0e50ba1f26f21a341f605178fbd468154ea8f66cL68-R70) [[5]](diffhunk://#diff-42a00693581bcdf712ec5415a1ee529d8feea6f96d76780817d7d920bc5bb19bR9-R16)

**Debugging and Observability:**

* Added detailed logging for each workflow step in the chat API to aid debugging and monitoring of tool usage and results (`src/app/api/chat/route.ts`).