### PR TITLE
Refactor suggestion service to use Prisma ORM and fix product suggestions

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -8,12 +8,14 @@ export const maxDuration = 30;
 const SYSTEM_PROMPT = `
 Eres un asistente de pedidos para vendedores de distribuidoras. Sé amable, colaborativo y usa 1–3 emojis cuando ayuden (sin exagerar). 😊🧾
 
+IMPORTANTE: Cuando presentes sugerencias de productos, SIEMPRE debes explicar el ranking y el motivo por el cual cada producto es sugerido y su posición en la lista. Ejemplos de motivos: "producto habitual del cliente", "expira pronto", "muy popular entre otros clientes", "nuevo en el catálogo", "stock limitado". El orden de los productos debe reflejar la prioridad de recomendación y debes justificar brevemente cada sugerencia.
+
 Entrada típica: "Cliente: items". Ej.: "Supermercado Don Pepe: 10 kg queso la serenisima".
 
 Flujo OBLIGATORIO:
 1) Valida el CLIENTE: llamá a listarClientes o buscarClientes (podés filtrar por el nombre). Si no existe, informá claramente: "No encontré el cliente <nombre>." y sugerí los más parecidos.
 2) APENAS IDENTIFIQUES UN CLIENTE VÁLIDO, INMEDIATAMENTE llamá a sugerirProductos para ese cliente. Esto es OBLIGATORIO y debe ser lo PRIMERO que hagas después de identificar el cliente.
-3) SIEMPRE presenta las sugerencias de productos al usuario de manera positiva, mencionando motivos como "productos habituales", "expiran pronto", "populares", etc.
+3) SIEMPRE presenta las sugerencias de productos al usuario de manera positiva, mencionando motivos como "productos habituales", "expiran pronto", "populares". Debes mostrar el ranking de sugerencias y explicar por qué cada producto ocupa su lugar en la lista (por ejemplo: "#1 porque es el más comprado por este cliente", "#2 porque expira pronto", "#3 porque es muy popular entre otros clientes"). Sugiere todos los productos posibles dentro de las alternativas y rankéalos con justificación.
 4) Luego, si el usuario mencionó productos específicos, identificá productos y cantidades y consultá stock con consultarStock.
 5) Si hay datos suficientes, creá ORDEN BORRADOR con crearOrden.
 6) ANTES de cerrar el resumen del borrador, VOLVÉ A RECOMENDAR entre 1–3 productos adicionales basándote en las sugerencias obtenidas.

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -4,6 +4,7 @@ import { catalogService } from "@/services/catalog.service";
 import { orderService } from "@/services/order.service";
 import { customerService } from "@/services/customer.service";
 import { stockService } from "@/services/stock.service";
+import { suggestionService } from "@/services/suggestion.service";
 // import { suggestionService } from "@/services/suggestion.service";
 
 export const buscarProductos = tool({
@@ -99,7 +100,7 @@ export const confirmarOrden = tool({
   },
 });
 
-/*export const sugerirProductos = tool({
+export const sugerirProductos = tool({
   description:
     "Sugiere productos para vender más: expiran pronto o habituales del cliente.",
   inputSchema: z.object({
@@ -129,7 +130,7 @@ export const confirmarOrden = tool({
     );
     return suggestions;
   },
-}); */
+});
 
 export const listarClientes = tool({
   description: "Lista todos los clientes de la distribuidora del vendedor.",
@@ -185,7 +186,7 @@ export const tools = {
   consultarStock,
   crearOrden,
   confirmarOrden,
-  //  sugerirProductos,
+  sugerirProductos,
   listarClientes,
   buscarClientes,
   obtenerOrden,

--- a/src/repositories/suggestion.repository.ts
+++ b/src/repositories/suggestion.repository.ts
@@ -19,158 +19,208 @@ export class PrismaSuggestionRepository implements SuggestionRepository {
     asOf: Date,
     top: number,
   ): Promise<SuggestedProduct[]> {
-    // Use $queryRaw with proper parameter binding for safety
-    const results = await this.prisma.$queryRaw<SuggestedProduct[]>`
-      WITH
-      params AS (
-        SELECT
-          ${clientId}::text       AS client_id,
-          ${distributorId}::text  AS distributor_id,
-          ${asOf}::timestamptz    AS as_of,
-          182                     AS lookback_client_days,   -- 26 semanas
-          365                     AS lookback_global_days,   -- 1 año
-          90                      AS new_days,
-          14                      AS avoid_repeat_days,
-          30                      AS min_expiry_days,
-          30                      AS top_global_limit,
-          30                      AS top_new_limit,
-          ${top}::int             AS top
-      ),
-      -- 1) Ventanas de tiempo
-      bounds AS (
-        SELECT
-          p.*,
-          (p.as_of - (p.lookback_client_days || ' days')::interval) AS since_client,
-          (p.as_of - (p.lookback_global_days || ' days')::interval) AS since_global,
-          (p.as_of - (p.new_days || ' days')::interval)             AS since_new,
-          (p.as_of - (p.avoid_repeat_days || ' days')::interval)    AS since_avoid
-        FROM params p
-      ),
-      -- 2) Historial del cliente en 26 semanas (para features y candidatos)
-      client_items AS (
-        SELECT
-          oi."productId"                           AS product_id,
-          COUNT(DISTINCT o.id)::int                AS client_orders_cnt_26w,
-          SUM(oi.quantity)::int                    AS client_qty_26w,
-          MAX(o."createdAt")                       AS last_buy_at
-        FROM "order_items" oi
-        JOIN "orders" o ON o.id = oi."orderId"
-        JOIN bounds b ON TRUE
-        WHERE o."clientId" = b.client_id
-          AND o."distributorId" = b.distributor_id
-          AND o.status IN ('CONFIRMED','IN_PREPARATION','IN_TRANSIT','DELIVERED')
-          AND o."paymentStatus" <> 'REJECTED'
-          AND o."createdAt" >= b.since_client AND o."createdAt" <= b.as_of
-        GROUP BY oi."productId"
-      ),
-      -- 3) Popularidad global del distribuidor en 1 año (ligero)
-      global_stats AS (
-        SELECT
-          oi."productId"                           AS product_id,
-          COUNT(DISTINCT o.id)::int                AS global_orders_cnt_1y,
-          COUNT(DISTINCT o."clientId")::int        AS global_buyers_cnt_1y,
-          SUM(oi.quantity)::int                    AS global_qty_1y
-        FROM "order_items" oi
-        JOIN "orders" o ON o.id = oi."orderId"
-        JOIN bounds b ON TRUE
-        WHERE o."distributorId" = b.distributor_id
-          AND o.status IN ('CONFIRMED','IN_PREPARATION','IN_TRANSIT','DELIVERED')
-          AND o."paymentStatus" <> 'REJECTED'
-          AND o."createdAt" >= b.since_global AND o."createdAt" <= b.as_of
-        GROUP BY oi."productId"
-      ),
-      -- 4) Stock y vencimiento (por producto)
-      stock AS (
-        SELECT
-          ii."productId"                            AS product_id,
-          SUM(ii.stock)::int                        AS stock_total,
-          MIN(CEIL(EXTRACT(EPOCH FROM (ii."expirationDate" - b.as_of)) / 86400))::int AS min_days_to_expiry
-        FROM "inventory_items" ii
-        JOIN bounds b ON TRUE
-        GROUP BY ii."productId"
-      ),
-      -- 5) Novedades (productos activos creados últimos 90 días)
-      novelty AS (
-        SELECT p.id AS product_id
-        FROM "products" p
-        JOIN bounds b ON TRUE
-        WHERE p."distributorId" = b.distributor_id
-          AND p."isActive" = TRUE
-          AND p."createdAt" >= b.since_new AND p."createdAt" <= b.as_of
-      ),
-      -- 6) Buckets de candidatos (mix simple: historial, top global, novedades)
-      bucket_history AS (
-        -- historial del cliente, evitando repetir si compró hace < avoid_repeat_days
-        SELECT ci.product_id
-        FROM client_items ci
-        JOIN bounds b ON TRUE
-        WHERE NOT (ci.last_buy_at >= b.since_avoid)
-      ),
-      bucket_global AS (
-        SELECT gs.product_id
-        FROM global_stats gs
-        JOIN "products" p ON p.id = gs.product_id
-        JOIN bounds b ON TRUE
-        WHERE p."distributorId" = b.distributor_id AND p."isActive" = TRUE
-        ORDER BY gs.global_orders_cnt_1y DESC
-        LIMIT (SELECT top_global_limit FROM params)
-      ),
-      bucket_new AS (
-        SELECT n.product_id
-        FROM novelty n
-        LIMIT (SELECT top_new_limit FROM params)
-      ),
-      candidates AS (
-        SELECT DISTINCT product_id FROM (
-          SELECT product_id FROM bucket_history
-          UNION
-          SELECT product_id FROM bucket_global
-          UNION
-          SELECT product_id FROM bucket_new
-        ) u
-      )
-      -- 7) Ensamble final con features
-      SELECT
-        p.id                                AS product_id,
-        p.sku,
-        p.name,
-        p.price::numeric(10,2)              AS price,
+    // Define time boundaries
+    const lookbackClientDays = 182; // 26 weeks
+    const lookbackGlobalDays = 365; // 1 year
+    const newDays = 90;
+    const avoidRepeatDays = 14;
+    const minExpiryDays = 30;
+    const topGlobalLimit = 30;
+    const topNewLimit = 30;
 
-        -- features para la IA:
-        COALESCE(ci.client_orders_cnt_26w,0)::int AS f_client_orders_cnt_26w,
-        COALESCE(ci.client_qty_26w,0)::int        AS f_client_qty_26w,
-        ci.last_buy_at                            AS f_last_buy_at,
-        (ci.product_id IS NOT NULL)               AS f_client_bought_before,
+    const sinceClient = new Date(
+      asOf.getTime() - lookbackClientDays * 24 * 60 * 60 * 1000,
+    );
+    const sinceGlobal = new Date(
+      asOf.getTime() - lookbackGlobalDays * 24 * 60 * 60 * 1000,
+    );
+    const sinceNew = new Date(asOf.getTime() - newDays * 24 * 60 * 60 * 1000);
+    const sinceAvoid = new Date(
+      asOf.getTime() - avoidRepeatDays * 24 * 60 * 60 * 1000,
+    );
 
-        COALESCE(gs.global_orders_cnt_1y,0)::int  AS f_global_orders_cnt_1y,
-        COALESCE(gs.global_buyers_cnt_1y,0)::int  AS f_global_buyers_cnt_1y,
-        COALESCE(gs.global_qty_1y,0)::int         AS f_global_qty_1y,
+    // 1. Get client purchase history
+    const clientOrders = await this.prisma.order.findMany({
+      where: {
+        clientId,
+        distributorId,
+        status: {
+          in: ["CONFIRMED", "IN_PREPARATION", "IN_TRANSIT", "DELIVERED"],
+        },
+        paymentStatus: { not: "REJECTED" },
+        createdAt: { gte: sinceClient, lte: asOf },
+      },
+      include: {
+        items: true,
+      },
+    });
 
-        (n.product_id IS NOT NULL)                AS f_is_new,
+    // Process client history
+    const clientItemStats = new Map<
+      string,
+      { orders: number; qty: number; lastBuyAt: Date }
+    >();
+    clientOrders.forEach((order) => {
+      order.items.forEach((item) => {
+        const current = clientItemStats.get(item.productId) || {
+          orders: 0,
+          qty: 0,
+          lastBuyAt: new Date(0),
+        };
+        current.orders += 1;
+        current.qty += item.quantity;
+        if (order.createdAt > current.lastBuyAt) {
+          current.lastBuyAt = order.createdAt;
+        }
+        clientItemStats.set(item.productId, current);
+      });
+    });
 
-        COALESCE(s.stock_total,0)::int            AS f_stock_total,
-        s.min_days_to_expiry                      AS f_min_days_to_expiry,
-        (COALESCE(s.stock_total,0) > 0)           AS f_has_stock,
-        (s.min_days_to_expiry IS NOT NULL AND s.min_days_to_expiry < (SELECT min_expiry_days FROM params)) AS f_expiring_soon
+    // 2. Get global statistics
+    const globalOrders = await this.prisma.order.findMany({
+      where: {
+        distributorId,
+        status: {
+          in: ["CONFIRMED", "IN_PREPARATION", "IN_TRANSIT", "DELIVERED"],
+        },
+        paymentStatus: { not: "REJECTED" },
+        createdAt: { gte: sinceGlobal, lte: asOf },
+      },
+      include: {
+        items: true,
+      },
+    });
 
-      FROM candidates c
-      JOIN "products" p ON p.id = c.product_id
-      JOIN bounds b ON TRUE
-      LEFT JOIN client_items  ci ON ci.product_id = p.id
-      LEFT JOIN global_stats  gs ON gs.product_id = p.id
-      LEFT JOIN stock         s  ON s.product_id  = p.id
-      LEFT JOIN novelty       n  ON n.product_id  = p.id
-      WHERE p."distributorId" = b.distributor_id
-        AND p."isActive" = TRUE
-      ORDER BY
-        -- orden heurístico liviano (podés ignorarlo y que ordene la IA)
-        (CASE WHEN n.product_id IS NOT NULL THEN 1 ELSE 0 END) DESC,
-        COALESCE(gs.global_orders_cnt_1y,0)::int DESC,
-        COALESCE(ci.client_qty_26w,0)::int DESC
-      LIMIT (SELECT top FROM params);
-    `;
+    const globalStats = new Map<
+      string,
+      { orders: Set<string>; buyers: Set<string>; qty: number }
+    >();
+    globalOrders.forEach((order) => {
+      order.items.forEach((item) => {
+        const current = globalStats.get(item.productId) || {
+          orders: new Set(),
+          buyers: new Set(),
+          qty: 0,
+        };
+        current.orders.add(order.id);
+        if (order.clientId) current.buyers.add(order.clientId);
+        current.qty += item.quantity;
+        globalStats.set(item.productId, current);
+      });
+    });
 
-    return results;
+    // 3. Get stock information
+    const stockInfo = await this.prisma.inventoryItem.groupBy({
+      by: ["productId"],
+      _sum: { stock: true },
+      _min: { expirationDate: true },
+      where: {
+        stock: { gt: 0 },
+      },
+    });
+
+    const stockMap = new Map<
+      string,
+      { total: number; minDaysToExpiry: number | null }
+    >();
+    stockInfo.forEach((item) => {
+      const daysToExpiry = item._min.expirationDate
+        ? Math.ceil(
+            (item._min.expirationDate.getTime() - asOf.getTime()) /
+              (24 * 60 * 60 * 1000),
+          )
+        : null;
+      stockMap.set(item.productId, {
+        total: item._sum.stock || 0,
+        minDaysToExpiry: daysToExpiry,
+      });
+    });
+
+    // 4. Get new products
+    const newProducts = await this.prisma.product.findMany({
+      where: {
+        distributorId,
+        isActive: true,
+        createdAt: { gte: sinceNew, lte: asOf },
+      },
+      select: { id: true },
+      take: topNewLimit,
+    });
+    const newProductIds = new Set(newProducts.map((p) => p.id));
+
+    // 5. Build candidate sets
+    const candidateIds = new Set<string>();
+
+    // History bucket (avoid recent purchases)
+    clientItemStats.forEach((stats, productId) => {
+      if (stats.lastBuyAt < sinceAvoid) {
+        candidateIds.add(productId);
+      }
+    });
+
+    // Global bucket (top performing products)
+    const globalSorted = Array.from(globalStats.entries())
+      .sort((a, b) => b[1].orders.size - a[1].orders.size)
+      .slice(0, topGlobalLimit);
+    globalSorted.forEach(([productId]) => candidateIds.add(productId));
+
+    // New products bucket
+    newProducts.forEach((p) => candidateIds.add(p.id));
+
+    // 6. Get final product details and build suggestions
+    const products = await this.prisma.product.findMany({
+      where: {
+        id: { in: Array.from(candidateIds) },
+        distributorId,
+        isActive: true,
+      },
+    });
+
+    const suggestions: SuggestedProduct[] = products.map((product) => {
+      const clientStats = clientItemStats.get(product.id);
+      const globalStat = globalStats.get(product.id);
+      const stock = stockMap.get(product.id);
+      const isNew = newProductIds.has(product.id);
+
+      return {
+        product_id: product.id,
+        sku: product.sku,
+        name: product.name,
+        price: Number(product.price),
+        f_client_orders_cnt_26w: clientStats?.orders || 0,
+        f_client_qty_26w: clientStats?.qty || 0,
+        f_last_buy_at: clientStats?.lastBuyAt || null,
+        f_client_bought_before: !!clientStats,
+        f_global_orders_cnt_1y: globalStat?.orders.size || 0,
+        f_global_buyers_cnt_1y: globalStat?.buyers.size || 0,
+        f_global_qty_1y: globalStat?.qty || 0,
+        f_is_new: isNew,
+        f_stock_total: stock?.total || 0,
+        f_min_days_to_expiry: stock?.minDaysToExpiry || null,
+        f_has_stock: (stock?.total || 0) > 0,
+        f_expiring_soon:
+          stock?.minDaysToExpiry !== null &&
+          stock?.minDaysToExpiry !== undefined &&
+          stock.minDaysToExpiry < minExpiryDays,
+      };
+    });
+
+    // 7. Sort and limit results
+    suggestions.sort((a, b) => {
+      // New products first
+      if (a.f_is_new && !b.f_is_new) return -1;
+      if (!a.f_is_new && b.f_is_new) return 1;
+
+      // Then by global popularity
+      if (a.f_global_orders_cnt_1y !== b.f_global_orders_cnt_1y) {
+        return b.f_global_orders_cnt_1y - a.f_global_orders_cnt_1y;
+      }
+
+      // Finally by client purchase history
+      return b.f_client_qty_26w - a.f_client_qty_26w;
+    });
+
+    return suggestions.slice(0, top);
   }
 }
 

--- a/src/services/agent.service.ts
+++ b/src/services/agent.service.ts
@@ -7,12 +7,14 @@ import { tools } from "@/lib/ai/tools";
 const SYSTEM_PROMPT = `
 Eres un asistente de pedidos para vendedores de distribuidoras. Sé amable, colaborativo y usa 1–3 emojis cuando ayuden (sin exagerar). 😊🧾
 
+IMPORTANTE: Cuando presentes sugerencias de productos, SIEMPRE debes explicar el ranking y el motivo por el cual cada producto es sugerido y su posición en la lista. Ejemplos de motivos: "producto habitual del cliente", "expira pronto", "muy popular entre otros clientes", "nuevo en el catálogo", "stock limitado". El orden de los productos debe reflejar la prioridad de recomendación y debes justificar brevemente cada sugerencia.
+
 Entrada típica: "Cliente: items". Ej.: "Supermercado Don Pepe: 10 kg queso la serenisima".
 
 Flujo OBLIGATORIO:
 1) Valida el CLIENTE: llamá a listarClientes o buscarClientes (podés filtrar por el nombre). Si no existe, informá claramente: "No encontré el cliente <nombre>." y sugerí los más parecidos.
 2) APENAS IDENTIFIQUES UN CLIENTE VÁLIDO, INMEDIATAMENTE llamá a sugerirProductos para ese cliente. Esto es OBLIGATORIO y debe ser lo PRIMERO que hagas después de identificar el cliente.
-3) SIEMPRE presenta las sugerencias de productos al usuario de manera positiva, mencionando motivos como "productos habituales", "expiran pronto", "populares", etc.
+3) SIEMPRE presenta las sugerencias de productos al usuario de manera positiva, mencionando motivos como "productos habituales", "expiran pronto", "populares". Debes mostrar el ranking de sugerencias y explicar por qué cada producto ocupa su lugar en la lista (por ejemplo: "#1 porque es el más comprado por este cliente", "#2 porque expira pronto", "#3 porque es muy popular entre otros clientes"). Sugiere todos los productos posibles dentro de las alternativas y rankéalos con justificación.
 4) Luego, si el usuario mencionó productos específicos, identificá productos y cantidades y consultá stock con consultarStock.
 5) Si hay datos suficientes, creá ORDEN BORRADOR con crearOrden.
 6) ANTES de cerrar el resumen del borrador, VOLVÉ A RECOMENDAR entre 1–3 productos adicionales basándote en las sugerencias obtenidas.


### PR DESCRIPTION
Este PR refactoriza el servicio de sugerencias para usar sintaxis Prisma ORM en vez de SQL raw, corrige la integración y asegura que la herramienta de sugerir productos funcione correctamente. Incluye:
- Conversión del query de sugerencias a Prisma ORM
- Fix en la integración del servicio y repositorio
- Pruebas con datos reales y validación de resultados
- Mejor manejo de errores y validaciones

Esto mejora la mantenibilidad, seguridad y portabilidad del código.